### PR TITLE
Javascript Bundle Diet를 위한 Code Splitting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,22 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { GlobalStyle, Positioner, ContentWrapper } from './Style/GlobalStyle';
 import Router from './Router';
 import { BrowserRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
-import { CookiesProvider } from 'react-cookie';
 
 const App: React.FC = () => {
 	return (
 		<RecoilRoot>
-			<CookiesProvider>
-				<BrowserRouter>
-					<GlobalStyle />
-					<Positioner>
-						<ContentWrapper>
+			<BrowserRouter>
+				<GlobalStyle />
+				<Positioner>
+					<ContentWrapper>
+						<Suspense fallback={<div />}>
 							<Router />
-						</ContentWrapper>
-					</Positioner>
-				</BrowserRouter>
-			</CookiesProvider>
+						</Suspense>
+					</ContentWrapper>
+				</Positioner>
+			</BrowserRouter>
 		</RecoilRoot>
 	);
 };

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,42 +1,141 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import PrivateRoute from 'Utils/Libs/PrivateRoute';
 import PublicRoute from 'Utils/Libs/PublicRoute';
-
-import {
-	HomePage,
-	SelfStudyPage,
-	SongPage,
-	NoticePage,
-	SigninPage,
-	SignupPage,
-	NoticeWritePage,
-	AuthorizationPage,
-	PwChangePage,
-	WithdrawlPage,
-	NotFoundPage,
-	PromotionPage,
-	PenaltyPage,
-	MassagePage,
-} from './Pages';
+const HomePage = lazy(() => import('./Pages/HomePage/HomePage'));
+const PromotionPage = lazy(() => import('./Pages/PromotionPage/PromotionPage'));
+const SelfStudyPage = lazy(() => import('./Pages/SelfStudyPage/SelfStudyPage'));
+const NoticePage = lazy(() => import('./Pages/NoticePage/NoticePage'));
+const NoticeWritePage = lazy(
+	() => import('./Pages/NoticeWritePage/NoticeWritePage')
+);
+const SongPage = lazy(() => import('./Pages/SongPage/SongPage'));
+const SigninPage = lazy(() => import('./Pages/SigninPage/SigninPage'));
+const SignupPage = lazy(() => import('./Pages/SignupPage/SignupPage'));
+const PwChangePage = lazy(() => import('./Pages/PwChangePage/PwChangePage'));
+const AuthorizationPage = lazy(
+	() => import('./Pages/AuthorizationPage/AuthorizationPage')
+);
+const WithdrawlPage = lazy(() => import('./Pages/WithdrawlPage/WithdrawlPage'));
+const PenaltyPage = lazy(() => import('./Pages/PenaltyPage/PenaltyPage'));
+const MassagePage = lazy(() => import('./Pages/MassagePage/MassagePage'));
+const NotFoundPage = lazy(() => import('./Pages/NotFoundPage/NotFoundPage'));
 
 const Router: React.FC = () => {
 	return (
 		<Routes>
-			<Route path="/" element={<PublicRoute restricted={false}><PromotionPage/></PublicRoute>} />
-			<Route path="/home" element={<PrivateRoute><HomePage/></PrivateRoute>}/>
-			<Route path="/selfstudy" element={<PrivateRoute><SelfStudyPage/></PrivateRoute>}/>
-			<Route path="/notice" element={<PrivateRoute><NoticePage/></PrivateRoute>}/>						
-			<Route path="/notice/write" element={<PrivateRoute><NoticeWritePage/></PrivateRoute>}/>
-			<Route path="/song" element={<PrivateRoute><SongPage/></PrivateRoute>}/>
-			<Route path="/signin" element={<PublicRoute restricted={false}><SigninPage/></PublicRoute>}/>
-			<Route path="/signup" element={<PublicRoute restricted={false}><SignupPage /></PublicRoute>}/>
-			<Route path="/password" element={<PublicRoute restricted={false}><PwChangePage/></PublicRoute>}/>
-			<Route path="/authorization" element={<PrivateRoute><AuthorizationPage/></PrivateRoute>}/>
-			<Route path="/Withdrawl" element={<PrivateRoute><WithdrawlPage/></PrivateRoute>}/>
-			<Route path="/change/password" element={<PrivateRoute><PwChangePage/></PrivateRoute>}/>																								
-			<Route path="/penalty" element={<PrivateRoute><PenaltyPage/></PrivateRoute>}/>
-			<Route path="/massage" element={<PrivateRoute><MassagePage/></PrivateRoute>}/>
+			<Route
+				path="/"
+				element={
+					<PublicRoute restricted={false}>
+						<PromotionPage />
+					</PublicRoute>
+				}
+			/>
+			<Route
+				path="/home"
+				element={
+					<PrivateRoute>
+						<HomePage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/selfstudy"
+				element={
+					<PrivateRoute>
+						<SelfStudyPage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/notice"
+				element={
+					<PrivateRoute>
+						<NoticePage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/notice/write"
+				element={
+					<PrivateRoute>
+						<NoticeWritePage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/song"
+				element={
+					<PrivateRoute>
+						<SongPage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/signin"
+				element={
+					<PublicRoute restricted={false}>
+						<SigninPage />
+					</PublicRoute>
+				}
+			/>
+			<Route
+				path="/signup"
+				element={
+					<PublicRoute restricted={false}>
+						<SignupPage />
+					</PublicRoute>
+				}
+			/>
+			<Route
+				path="/password"
+				element={
+					<PublicRoute restricted={false}>
+						<PwChangePage />
+					</PublicRoute>
+				}
+			/>
+			<Route
+				path="/authorization"
+				element={
+					<PrivateRoute>
+						<AuthorizationPage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/Withdrawl"
+				element={
+					<PrivateRoute>
+						<WithdrawlPage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/change/password"
+				element={
+					<PrivateRoute>
+						<PwChangePage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/penalty"
+				element={
+					<PrivateRoute>
+						<PenaltyPage />
+					</PrivateRoute>
+				}
+			/>
+			<Route
+				path="/massage"
+				element={
+					<PrivateRoute>
+						<MassagePage />
+					</PrivateRoute>
+				}
+			/>
 			<Route element={<NotFoundPage />} />
 		</Routes>
 	);


### PR DESCRIPTION
## 한 일
- code splitting을 route level로 진행했습니다.

### code splitting 진행이전
<img width="686" alt="스크린샷 2022-03-12 오후 3 19 52" src="https://user-images.githubusercontent.com/66630940/158006639-a4b27d91-60dc-4dd3-a9ae-ff4166d931c9.png">

### 코드 스플리팅 진행 이후
<img width="677" alt="스크린샷 2022-03-10 오후 8 46 01" src="https://user-images.githubusercontent.com/66630940/158006505-c9c1ce89-6265-4fe3-886e-85d8428ca82c.png">


개발환경에서의 비교로는 확연하게 차이점이 보이는게 main과 vendor의 chunk 파일 사이즈와 time을 보면 어마어마 하지만
code splitting 진행 이후에는 서로 다 나뉘기때문에 더욱 빠른 render를 할 수 있다.

