### PR TITLE
Fix: 기상음악 달력 표기 수정

### DIFF
--- a/src/Atoms/AtomContainer.ts
+++ b/src/Atoms/AtomContainer.ts
@@ -57,3 +57,8 @@ export const classLookuped = atom<boolean>({
 	key: 'classLookuped',
 	default: false,
 });
+
+export const selectDate = atom<Date>({
+	key: 'selectDate',
+	default: new Date(),
+})

--- a/src/Atoms/index.ts
+++ b/src/Atoms/index.ts
@@ -5,6 +5,7 @@ import {
 	showPlaylistDate,
 	setList,
 	classLookuped,
+	selectDate,
 } from './AtomContainer';
 
 export {
@@ -14,4 +15,5 @@ export {
 	showPlaylistDate,
 	setList,
 	classLookuped,
+	selectDate,
 };

--- a/src/Components/CalendarModal/CalendarModal.tsx
+++ b/src/Components/CalendarModal/CalendarModal.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Calendar from 'react-calendar';
 import { dateMusic } from 'Api/music';
 import * as S from './Style';
-import { useRecoilState } from 'recoil';
-import { isCalendarOpen, setList, showPlaylistDate } from 'Atoms';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { isCalendarOpen, selectDate, setList, showPlaylistDate } from 'Atoms';
 import { DateFormatter } from '../../Utils/DateFormatter';
 import { useRole } from 'Hooks/useRole';
 import { mutate } from 'swr';
@@ -17,10 +17,10 @@ const getDateMusic = async (date: any, role: string) => {
 };
 
 const CalendarModal: React.FC<calendar> = ({ visible }) => {
-	const [, setSongList] = useRecoilState(setList);
-	const [playlistDate] = useRecoilState(showPlaylistDate);
+	const setSongList = useSetRecoilState(setList);
+	const [playlistDate, setPlaylistDate] = useRecoilState(showPlaylistDate);
 	const [calendarOpen, setCalendarOpen] = useRecoilState(isCalendarOpen);
-	const [, setPlaylistDate] = useRecoilState(showPlaylistDate);
+	const [select, setSelect] = useRecoilState(selectDate);
 	const role = useRole();
 
 	return (
@@ -33,14 +33,16 @@ const CalendarModal: React.FC<calendar> = ({ visible }) => {
 					/>
 					<S.CalendarWrapper>
 						<Calendar
-							onChange={(value) =>
+							onChange={(value) => {
+								setSelect(new Date(value.getFullYear(), value.getMonth(), value.getDate()));
 								getDateMusic(DateFormatter(value), role).then((res) => {
 									setSongList(res?.data.data);
 									setPlaylistDate(DateFormatter(value));
 									mutate(`/${role}/music?date=${playlistDate}`);
 								})
-							}
+							}}
 							calendarType="US"
+							value={select}
 						/>
 					</S.CalendarWrapper>
 				</S.CalendarContainer>


### PR DESCRIPTION
- 기상음악 달력에서 다른 날짜를 조회하고 달력을 다시 켰을 때 날짜는 오늘로 표기되고 음악은 전에 조회한 날짜에서 신청된 음악이 뜨는 현상 수정
- 선택한 날짜를 전역상태로 설정하여 해결