### PR TITLE
Fix: 달력 조회 후 다시 페이지 돌아올 때 표기 수정

### DIFF
--- a/src/Components/CalendarModal/CalendarModal.tsx
+++ b/src/Components/CalendarModal/CalendarModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Calendar from 'react-calendar';
 import { dateMusic } from 'Api/music';
 import * as S from './Style';
@@ -23,6 +23,15 @@ const CalendarModal: React.FC<calendar> = ({ visible }) => {
 	const [select, setSelect] = useRecoilState(selectDate);
 	const role = useRole();
 
+	useEffect(() => {
+		getDateMusic(DateFormatter(select), role).then((res) => {
+			console.log(select);
+			setSongList(res?.data.data);
+			setPlaylistDate(DateFormatter(select));
+			mutate(`/${role}/music?date=${playlistDate}`);
+		})
+	}, [select])
+
 	return (
 		<>
 			{calendarOpen && (
@@ -34,12 +43,7 @@ const CalendarModal: React.FC<calendar> = ({ visible }) => {
 					<S.CalendarWrapper>
 						<Calendar
 							onChange={(value) => {
-								setSelect(new Date(value.getFullYear(), value.getMonth(), value.getDate()));
-								getDateMusic(DateFormatter(value), role).then((res) => {
-									setSongList(res?.data.data);
-									setPlaylistDate(DateFormatter(value));
-									mutate(`/${role}/music?date=${playlistDate}`);
-								})
+								setSelect(value);
 							}}
 							calendarType="US"
 							value={select}

--- a/src/Components/CalendarModal/CalendarModal.tsx
+++ b/src/Components/CalendarModal/CalendarModal.tsx
@@ -25,7 +25,6 @@ const CalendarModal: React.FC<calendar> = ({ visible }) => {
 
 	useEffect(() => {
 		getDateMusic(DateFormatter(select), role).then((res) => {
-			console.log(select);
 			setSongList(res?.data.data);
 			setPlaylistDate(DateFormatter(select));
 			mutate(`/${role}/music?date=${playlistDate}`);

--- a/src/Components/TodaySong/TodaySong.tsx
+++ b/src/Components/TodaySong/TodaySong.tsx
@@ -3,7 +3,7 @@ import * as S from './Style';
 import * as I from '../../Assets/Svg/index';
 import { SongItem } from '../';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { isCalendarOpen, setList, showPlaylistDate } from 'Atoms';
+import { isCalendarOpen, selectDate, setList, showPlaylistDate } from 'Atoms';
 import { dateMusic } from 'Api/music';
 import CalendarModal from 'Components/CalendarModal/CalendarModal';
 import { useRole } from 'Hooks/useRole';
@@ -31,6 +31,7 @@ const TodaySong: React.FC = () => {
 	const setSongList = useSetRecoilState(setList);
 	const [playlistDate, setPlaylistDate] = useRecoilState(showPlaylistDate);
 	const [calendarOpen, setCalendarOpen] = useRecoilState(isCalendarOpen);
+	const setSelect = useSetRecoilState(selectDate);
 	const role = useRole();
 	const { data, error } = useSWR<MusicType>(
 		MusicController.dateMusic(role, playlistDate),
@@ -42,6 +43,7 @@ const TodaySong: React.FC = () => {
 	};
 
 	useEffect(() => {
+		setSelect(new Date());
 		setPlaylistDate(
 			`${ManufactureDate('Y')}-${('0' + ManufactureDate('M')).slice(-2)}-${(
 				'0' + ManufactureDate('D')


### PR DESCRIPTION
# 문제상황
달력에서 다른 날짜를 선택하고 다른 페이지로 접근 후 다시 기상음악 페이지로 접근하면 아래의 이미지와 같은 현상 발생
(음악들은 오늘 신청한 음악이 뜨지만 달력에는 전에 선택한 날짜가 표기)
![image](https://user-images.githubusercontent.com/87346613/186111471-011f1fb9-5d6b-4d9e-810b-a5601bce75fc.png)
# 해결
다시 기상음악 페이지로 되돌아왔을 때 오늘 날짜를 선택하도록 변경
