### PR TITLE
fix: youtube url 프로토콜 미작성 이슈 해결

### DIFF
--- a/src/Components/SongRequest/SongRequest.tsx
+++ b/src/Components/SongRequest/SongRequest.tsx
@@ -62,8 +62,7 @@ const returnBtn = (
 							if (url === '') {
 								toast.warning('아무것도 입력하지 않았어요');
 							} else if (CheckUrl(url)) {
-								if (!url.match("//")) setUrl("//" + url)
-								musicApply(url, role).then(async (res) => {
+								musicApply(CheckProtocol(url), role).then(async (res) => {
 									mutate(`/${role}/music?date=${playlistDate}`);
 									setUrl('');
 								});
@@ -79,8 +78,7 @@ const returnBtn = (
 						if (url === '') {
 							toast.warning('아무것도 입력하지 않았어요');
 						} else if (CheckUrl(url)) {
-							if (!url.match("//")) setUrl("//" + url)
-							musicApply(url, role).then(() => {
+							musicApply(CheckProtocol(url), role).then(async (res) => {
 								mutate(`/${role}/music?date=${playlistDate}`);
 								setUrl('');
 							});
@@ -136,5 +134,9 @@ export const CheckUrl = (url) => {
 		/^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$/;
 	return regex.test(url);
 };
+
+export const CheckProtocol = (url) => {
+	return url.match("//") ? url : "//" + url
+}
 
 export default SongRequest;

--- a/src/Components/SongRequest/SongRequest.tsx
+++ b/src/Components/SongRequest/SongRequest.tsx
@@ -62,6 +62,7 @@ const returnBtn = (
 							if (url === '') {
 								toast.warning('아무것도 입력하지 않았어요');
 							} else if (CheckUrl(url)) {
+								if (!url.match("//")) setUrl("//" + url)
 								musicApply(url, role).then(async (res) => {
 									mutate(`/${role}/music?date=${playlistDate}`);
 									setUrl('');
@@ -78,6 +79,7 @@ const returnBtn = (
 						if (url === '') {
 							toast.warning('아무것도 입력하지 않았어요');
 						} else if (CheckUrl(url)) {
+							if (!url.match("//")) setUrl("//" + url)
 							musicApply(url, role).then(() => {
 								mutate(`/${role}/music?date=${playlistDate}`);
 								setUrl('');

--- a/src/Components/SongRequest/SongRequest.tsx
+++ b/src/Components/SongRequest/SongRequest.tsx
@@ -21,8 +21,21 @@ const returnBtn = (
 	playlistDate: string
 ) => {
 	const today = ManufactureDate('W');
-
 	let cant = ['금', '토'];
+
+	const musicSubmit = () => {
+		if (url === '') {
+			toast.warning('아무것도 입력하지 않았어요');
+		} else if (CheckUrl(url)) {
+			musicApply(CheckProtocol(url), role).then(async (res) => {
+				mutate(`/${role}/music?date=${playlistDate}`);
+				setUrl('');
+			});
+		} else {
+			toast.warning('유튜브 링크만 추가하실 수 있어요');
+		}
+	}
+
 	if (role === 'admin') {
 		return (
 			<>
@@ -58,37 +71,12 @@ const returnBtn = (
 					onChange={({ target: { value } }) => setUrl(value)}
 					ref={songInput}
 					onKeyPress={(e) => {
-						if (e.key === 'Enter') {
-							if (url === '') {
-								toast.warning('아무것도 입력하지 않았어요');
-							} else if (CheckUrl(url)) {
-								musicApply(CheckProtocol(url), role).then(async (res) => {
-									mutate(`/${role}/music?date=${playlistDate}`);
-									setUrl('');
-								});
-							} else {
-								toast.warning('유튜브 링크만 추가하실 수 있어요');
-							}
-						}
+						if (e.key === 'Enter')
+							musicSubmit()
 					}}
 					value={url}
 				/>
-				<button
-					onClick={() => {
-						if (url === '') {
-							toast.warning('아무것도 입력하지 않았어요');
-						} else if (CheckUrl(url)) {
-							musicApply(CheckProtocol(url), role).then(async (res) => {
-								mutate(`/${role}/music?date=${playlistDate}`);
-								setUrl('');
-							});
-						} else {
-							toast.warning('유튜브 링크만 추가하실 수 있어요');
-						}
-					}}
-				>
-					신청하기
-				</button>
+				<button onClick={musicSubmit}>신청하기</button>
 			</>
 		);
 	}
@@ -129,13 +117,13 @@ const SongRequest: React.FC = () => {
 	);
 };
 
-export const CheckUrl = (url) => {
+const CheckUrl = (url) => {
 	let regex =
 		/^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?$/;
 	return regex.test(url);
 };
 
-export const CheckProtocol = (url) => {
+const CheckProtocol = (url) => {
 	return url.match("//") ? url : "//" + url
 }
 


### PR DESCRIPTION
## 이슈
기상음악 페이지 달력에서 '2022-12-04' 음악 리스트 중 상단에서 2번째 item을 클릭하면 아래와 같은 화면이 띄워지게 되는데
![image](https://user-images.githubusercontent.com/87346613/205593370-761ace9d-9b7a-43db-b3a6-ef2e7fe3e796.png)

아래와 같이 프로토콜을 쓰지 않은 url로 신청하면
![image](https://user-images.githubusercontent.com/87346613/205594164-4fd34e6e-3961-45c2-a8f2-9ea949219f1f.png)

도토리 baseurl에 유튜브 url이 붙은 상태가 됩니다.
![image](https://user-images.githubusercontent.com/87346613/205594571-3e6a437b-b532-4c11-92fa-ed14b69c139c.png)

## 변경사항
![image](https://user-images.githubusercontent.com/87346613/205602300-34b63e75-68bc-45da-9876-4d48f405afc5.png)
음악신청 전에 url에 프로토콜 구분자("//")를 포함하고 있는지 확인합니다.
프로토콜 구분자는 url의 맨 앞에 위치하면 그 앞에 있어야 할 프로토콜은 자동으로 치환되어 호출된다는 것을 이용하여 코드를 수정했습니다.

---
### 기상음악 신청 입력 방식
- http(s)://www.youtube.com/watch?v=LxhNTq_4NYs === (O)
- //www.youtube.com/watch?v=LxhNTq_4NYs === (O)
- www.youtube.com/watch?v=LxhNTq_4NYs === (X)